### PR TITLE
[#19] Use OpenAI to generate the search prompt

### DIFF
--- a/cmd/ask-web/main.go
+++ b/cmd/ask-web/main.go
@@ -36,11 +36,6 @@ func main() {
 		return true
 	}
 
-	var query string
-	if pflag.NArg() > 0 {
-		query = pflag.Arg(0)
-	}
-
 	apiKeys := utils.SetupKeys(opts.ConfigDir)
 
 	if opts.ShowAPIKeys {
@@ -51,6 +46,16 @@ func main() {
 		fmt.Println("CSE ID:", apiKeys.GoogleCSEID)
 		fmt.Println("OpenAI Key:", apiKeys.OpenAIKey)
 	}
+
+	var query string
+	if pflag.NArg() > 0 {
+		query, err = search.CreateSearchQuery(opts, apiKeys.OpenAIKey, pflag.Arg(0))
+		if err != nil {
+			query = pflag.Arg(0)
+		}
+	}
+	logger.Debug("Original prompt: ", pflag.Arg(0))
+	logger.Debug("Search query: ", query)
 
 	db, err := database.InitializeDB(opts.DBFileName, opts.DBTable)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,7 @@ type Opts struct {
 	DBFileName  string
 	DBTable     string
 
+	QueryPrompt   string
 	SummaryPrompt string
 
 	FilteredURLs []string
@@ -77,6 +78,7 @@ func Initialize() (*Opts, error) {
 	viper.SetDefault("model.max_tokens", 420)
 	viper.SetDefault("model.num_results", 3)
 	viper.SetDefault("model.temperature", 0.7)
+	viper.SetDefault("model.query_prompt", "Turn this prompt into a search query, ensuring to retain its meaning")
 	viper.SetDefault("model.summary_prompt", "Please provide a detailed summary of the following text that is directly related to the query")
 	viper.SetDefault("logging.file", defaultLogFileName)
 	viper.SetDefault("database.file", filepath.Join(configDir, "ask-web.db"))
@@ -90,6 +92,7 @@ func Initialize() (*Opts, error) {
 	pflag.IntP("num-results", "n", viper.GetInt("model.num_results"), "How many web pages to check per search engine")
 	pflag.IntP("context-length", "l", viper.GetInt("model.context_length"), "Maximum context length")
 	pflag.StringP("database", "d", viper.GetString("database.file"), "Database file")
+	pflag.StringP("query-prompt", "q", viper.GetString("model.query_prompt"), "Prompt for generating search query from prompt")
 	pflag.StringP("summary-prompt", "S", viper.GetString("model.summary_prompt"), "System prompt for LLM")
 	pflag.IntP("max-tokens", "t", viper.GetInt("model.max_tokens"), "Maximum tokens to generate")
 	pflag.Float64P("temperature", "T", viper.GetFloat64("model.temperature"), "Temperature for summarization")
@@ -135,6 +138,7 @@ func Initialize() (*Opts, error) {
 		LogFileName:   viper.GetString("logging.file"),
 		DBFileName:    os.ExpandEnv(viper.GetString("database.file")),
 		DBTable:       viper.GetString("database.table"),
+		QueryPrompt:   viper.GetString("model.query_prompt"),
 		SummaryPrompt: viper.GetString("model.summary_prompt"),
 		NumResults:    viper.GetInt("model.num_results"),
 		MaxTokens:     viper.GetInt("model.max_tokens"),

--- a/pkg/search/search.go
+++ b/pkg/search/search.go
@@ -1,5 +1,15 @@
 package search
 
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sashabaranov/go-openai"
+
+	"ask-web/pkg/config"
+)
+
 type SearchResult struct {
 	Title   string
 	URL     string
@@ -18,3 +28,40 @@ type FilterFunc func(SearchResult) bool
 
 const MaxTimeoutSeconds = 10
 const ExtraResultsFactor = 2.0
+
+// Take a query argument and then send it to the OpenAI API to generate a concise search query to use
+func CreateSearchQuery(opts *config.Opts, apiKey string, query string) (string, error) {
+	client := openai.NewClient(apiKey)
+
+	systemPrompt := "You are generating a query to pass to a search engine. Return only the query, do not generate extraneous information. Try not to include dates unless in the query itself; your knowledge base it cutoff and you may get it wrong."
+	prompt := fmt.Sprintf("%s: '%s'", opts.QueryPrompt, query)
+
+	ctx := context.Background()
+
+	req := openai.ChatCompletionRequest{
+		Model:       openai.GPT4oMini,
+		MaxTokens:   50,
+		Temperature: 0.3,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleSystem,
+				Content: systemPrompt,
+			},
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: prompt,
+			},
+		},
+	}
+
+	resp, err := client.CreateChatCompletion(ctx, req)
+	if err != nil {
+		return "", err
+	}
+
+	if len(resp.Choices) == 0 {
+		return "", errors.New("no query generated")
+	}
+
+	return resp.Choices[0].Message.Content, nil
+}


### PR DESCRIPTION
This allows the user to enter a long prompt, then let the LLM reduce it to a succinct search query.
